### PR TITLE
Disable auto-align before decomposing

### DIFF
--- a/UnnestComponents.glyphsFilter/Contents/Resources/plugin.py
+++ b/UnnestComponents.glyphsFilter/Contents/Resources/plugin.py
@@ -42,6 +42,7 @@ class UnnestComponents(FilterWithoutDialog):
 			while nestedComponents(currLayer):
 				for c in currLayer.components:
 					if c.componentLayer.components:
+						c.automaticAlignment = False
 						c.decompose()
 
 	@objc.python_method


### PR DESCRIPTION
Disable automatic alignment before decomposing, to prevent components from jumping to another position.

Example: `macronbelowcomb` is composed of a `macroncomb` component, which is shifted down below the baseline. Precomposed glyphs with `letter+macronbelowcomb` will have their `macronbelowcomb` decomposed to `macroncomb`, causing the macron to jump back above the glyph if automaticAlignment is enabled. Disabling automaticAlignment right before decomposing fixes this problem.